### PR TITLE
chore: enable Github CI workflow for android testing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,16 +27,26 @@ jobs:
           path: app/build/reports/test/testDebugUnitTest/
 
   instrumented-test:
-    runs-on: ubuntu-latest
+    name: Perform Instrumentation Testing
+    needs: [unit-test]
+    runs-on: macos-latest
     steps:
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Checkout the code
+        uses: actions/checkout@v2
 
-      - name: Run unit tests
-        run: ./gradlew test
-
-      - name: Upload test report
-        uses: actions.upload-artifact@v2
+      - name: Set up Java JDK 17
+        uses: actions/setup-java@v1
         with:
-          name: unit_test_report
-          path: app/build/reports/test/testDebugUnitTest/
+          java-version: '17'
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 36
+          script: ./gradlew connectedAndroidTest
+
+      - name: Upload Instrumentation Test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: instrumentation_test_report
+          path: app/build/reports/androidTests/connected


### PR DESCRIPTION
- include running unit tests
- include running instrumented tests
- can further enhance down the line with lint checking and other checks as deemed suitable