### PR TITLE
improvement(inc. fix): ensure fragment instrumented tests use real repository modules. Ensure user amendments are always on to the first row

### DIFF
--- a/app/src/androidTest/java/com/example/librewards/MainActivityInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/librewards/MainActivityInstrumentedTest.java
@@ -13,6 +13,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.android.dx.mockito.inline.extended.ExtendedMockito.mockitoSession;
+import static com.example.librewards.utils.TestUtils.clearTables;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -172,9 +173,6 @@ public class MainActivityInstrumentedTest {
 
     @After
     public void tearDown() {
-        db.delete("user_table", null, null);
-        db.delete("start_codes_table", null, null);
-        db.delete("stop_codes_table", null, null);
-        db.delete("reward_codes_table", null, null);
+        clearTables(db);
     }
 }

--- a/app/src/androidTest/java/com/example/librewards/RewardsFragmentInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/librewards/RewardsFragmentInstrumentedTest.java
@@ -11,16 +11,20 @@ import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.example.librewards.utils.FragmentTestUtils.launchFragmentInHiltContainer;
+import static com.example.librewards.utils.TestUtils.clearTables;
 
+import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.example.librewards.data.db.DatabaseHelper;
 import com.example.librewards.data.models.UserModel;
 import com.example.librewards.data.repositories.RewardsRepository;
 import com.example.librewards.data.repositories.UserRepository;
 import com.example.librewards.views.RewardsFragment;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +45,9 @@ public class RewardsFragmentInstrumentedTest {
     UserRepository userRepository;
     @Inject
     RewardsRepository rewardsRepository;
+    @Inject
+    DatabaseHelper databaseHelper;
+    private SQLiteDatabase db;
     private UserModel user;
     private static final int POINTS_VALUE_ID = R.id.pointsRewards;
     private static final int NAME_VALUE_ID = R.id.nameRewards;
@@ -54,6 +61,8 @@ public class RewardsFragmentInstrumentedTest {
     public void setUp() {
         hiltRule.inject();
         user = new UserModel(1, "test-name", 0);
+        db = databaseHelper.getWritableDatabase();
+
         userRepository.addName("test-name");
         rewardsRepository.populate();
 
@@ -102,5 +111,10 @@ public class RewardsFragmentInstrumentedTest {
         onView(withId(REWARDS_TEXT_ID)).perform(typeText("incorrect-code"), closeSoftKeyboard());
         onView(withId(REWARDS_BUTTON_ID)).perform(click());
         onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
+    }
+
+    @After
+    public void tearDown() {
+        clearTables(db);
     }
 }

--- a/app/src/androidTest/java/com/example/librewards/RewardsFragmentInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/librewards/RewardsFragmentInstrumentedTest.java
@@ -56,6 +56,7 @@ public class RewardsFragmentInstrumentedTest {
     private static final int REWARDS_TEXT_ID = R.id.rewardText;
     private static final int POPUP_TEXT = R.id.popupText;
     private static final int POPUP_CLOSE_BUTTON = R.id.closeBtn;
+    private Bundle bundle;
 
     @Before
     public void setUp() {
@@ -66,14 +67,14 @@ public class RewardsFragmentInstrumentedTest {
         userRepository.addName("test-name");
         rewardsRepository.populate();
 
-        Bundle bundle = new Bundle();
+        bundle = new Bundle();
         bundle.putParcelable("user", user);
-
-        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
     }
 
     @Test
     public void test_rewardsFragment_hasCoreUiElementsCorrectlySetup() {
+        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
+
         onView(withId(NAME_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("Hey, test-name")));
         onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
         onView(withId(POINTS_LABEL_ID)).check(matches(isDisplayed())).check(matches(withText("Points")));
@@ -84,6 +85,10 @@ public class RewardsFragmentInstrumentedTest {
     @Test
     public void test_rewardsFragment_givenCorrectCodeAndSufficientPoints_successfullyPurchasesItem() {
         userRepository.addPoints(user, 10);
+        user = userRepository.getUser();
+        bundle.putParcelable("user", user);
+        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
+
         onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
         onView(withId(REWARDS_TEXT_ID)).perform(typeText("943248"), closeSoftKeyboard());
         onView(withId(REWARDS_BUTTON_ID)).perform(click());
@@ -95,6 +100,8 @@ public class RewardsFragmentInstrumentedTest {
 
     @Test
     public void test_rewardsFragment_givenCorrectCodeButInsufficientPoints_providesInsufficientPointsMessage() {
+        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
+
         onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
         onView(withId(REWARDS_TEXT_ID)).perform(typeText("674382"), closeSoftKeyboard());
         onView(withId(REWARDS_BUTTON_ID)).perform(click());
@@ -106,6 +113,8 @@ public class RewardsFragmentInstrumentedTest {
 
     @Test
     public void test_rewardsFragment_givenIncorrectCode_doesNotPurchaseItem() {
+        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
+
         userRepository.addPoints(user, 10);
         onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
         onView(withId(REWARDS_TEXT_ID)).perform(typeText("incorrect-code"), closeSoftKeyboard());

--- a/app/src/androidTest/java/com/example/librewards/RewardsFragmentInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/librewards/RewardsFragmentInstrumentedTest.java
@@ -1,106 +1,106 @@
-//package com.example.librewards;
-//
-//import static androidx.test.espresso.Espresso.onView;
-//import static androidx.test.espresso.action.ViewActions.click;
-//import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-//import static androidx.test.espresso.action.ViewActions.typeText;
-//import static androidx.test.espresso.assertion.ViewAssertions.matches;
-//import static androidx.test.espresso.matcher.RootMatchers.isDialog;
-//import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-//import static androidx.test.espresso.matcher.ViewMatchers.withHint;
-//import static androidx.test.espresso.matcher.ViewMatchers.withId;
-//import static androidx.test.espresso.matcher.ViewMatchers.withText;
-//import static com.example.librewards.utils.FragmentTestUtils.launchFragmentInHiltContainer;
-//
-//import android.os.Bundle;
-//
-//import androidx.test.ext.junit.runners.AndroidJUnit4;
-//
-//import com.example.librewards.data.models.UserModel;
-//import com.example.librewards.repositories.RewardsRepositoryFake;
-//import com.example.librewards.repositories.UserRepositoryFake;
-//import com.example.librewards.views.RewardsFragment;
-//
-//import org.junit.Before;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//
-//import javax.inject.Inject;
-//
-//import dagger.hilt.android.testing.HiltAndroidRule;
-//import dagger.hilt.android.testing.HiltAndroidTest;
-//
-//@HiltAndroidTest
-//@RunWith(AndroidJUnit4.class)
-//public class RewardsFragmentInstrumentedTest {
-//
-//    @Rule
-//    public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
-//    @Inject
-//    UserRepositoryFake userRepositoryFake;
-//    @Inject
-//    RewardsRepositoryFake rewardsRepositoryFake;
-//    private UserModel user;
-//    private static final int POINTS_VALUE_ID = R.id.pointsRewards;
-//    private static final int NAME_VALUE_ID = R.id.nameRewards;
-//    private static final int POINTS_LABEL_ID = R.id.pointsLabelRewards;
-//    private static final int REWARDS_BUTTON_ID = R.id.rewardButton;
-//    private static final int REWARDS_TEXT_ID = R.id.rewardText;
-//    private static final int POPUP_TEXT = R.id.popupText;
-//    private static final int POPUP_CLOSE_BUTTON = R.id.closeBtn;
-//
-//    @Before
-//    public void setUp() {
-//        hiltRule.inject();
-//        user = new UserModel(1, "test-name", 0);
-//        userRepositoryFake.setUser(user);
-//        rewardsRepositoryFake.populate();
-//
-//        Bundle bundle = new Bundle();
-//        bundle.putParcelable("user", user);
-//
-//        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
-//    }
-//
-//    @Test
-//    public void test_rewardsFragment_hasCoreUiElementsCorrectlySetup() {
-//        onView(withId(NAME_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("Hey, test-name")));
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
-//        onView(withId(POINTS_LABEL_ID)).check(matches(isDisplayed())).check(matches(withText("Points")));
-//        onView(withId(REWARDS_BUTTON_ID)).check(matches(isDisplayed())).check(matches(withText("GET REWARDED NOW!")));
-//        onView(withId(REWARDS_TEXT_ID)).check(matches(withHint("Please enter your chosen reward code")));
-//    }
-//
-//    @Test
-//    public void test_rewardsFragment_givenCorrectCodeAndSufficientPoints_successfullyPurchasesItem() {
-//        userRepositoryFake.addPoints(user, 10);
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
-//        onView(withId(REWARDS_TEXT_ID)).perform(typeText("123456"), closeSoftKeyboard());
-//        onView(withId(REWARDS_BUTTON_ID)).perform(click());
-//        onView(withId(POPUP_TEXT)).inRoot(isDialog()).check(matches(withText("Code accepted, keep it up! Your new " +
-//                "points balance is: 5")));
-//        onView(withId(POPUP_CLOSE_BUTTON)).inRoot(isDialog()).perform(click());
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("5")));
-//    }
-//
-//    @Test
-//    public void test_rewardsFragment_givenCorrectCodeButInsufficientPoints_providesInsufficientPointsMessage() {
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
-//        onView(withId(REWARDS_TEXT_ID)).perform(typeText("123456"), closeSoftKeyboard());
-//        onView(withId(REWARDS_BUTTON_ID)).perform(click());
-//        onView(withId(POPUP_TEXT)).inRoot(isDialog()).check(matches(withText("Woops! Unfortunately you don't have " +
-//                "sufficient points for this reward. Please choose another reward or carry on doing a great job at the " +
-//                "library to be able to get this")));
-//        onView(withId(POPUP_CLOSE_BUTTON)).inRoot(isDialog()).perform(click());
-//    }
-//
-//    @Test
-//    public void test_rewardsFragment_givenIncorrectCode_doesNotPurchaseItem() {
-//        userRepositoryFake.addPoints(user, 10);
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
-//        onView(withId(REWARDS_TEXT_ID)).perform(typeText("incorrect-code"), closeSoftKeyboard());
-//        onView(withId(REWARDS_BUTTON_ID)).perform(click());
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
-//    }
-//}
+package com.example.librewards;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.example.librewards.utils.FragmentTestUtils.launchFragmentInHiltContainer;
+
+import android.os.Bundle;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.example.librewards.data.models.UserModel;
+import com.example.librewards.data.repositories.RewardsRepository;
+import com.example.librewards.data.repositories.UserRepository;
+import com.example.librewards.views.RewardsFragment;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class RewardsFragmentInstrumentedTest {
+
+    @Rule
+    public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+    @Inject
+    UserRepository userRepository;
+    @Inject
+    RewardsRepository rewardsRepository;
+    private UserModel user;
+    private static final int POINTS_VALUE_ID = R.id.pointsRewards;
+    private static final int NAME_VALUE_ID = R.id.nameRewards;
+    private static final int POINTS_LABEL_ID = R.id.pointsLabelRewards;
+    private static final int REWARDS_BUTTON_ID = R.id.rewardButton;
+    private static final int REWARDS_TEXT_ID = R.id.rewardText;
+    private static final int POPUP_TEXT = R.id.popupText;
+    private static final int POPUP_CLOSE_BUTTON = R.id.closeBtn;
+
+    @Before
+    public void setUp() {
+        hiltRule.inject();
+        user = new UserModel(1, "test-name", 0);
+        userRepository.addName("test-name");
+        rewardsRepository.populate();
+
+        Bundle bundle = new Bundle();
+        bundle.putParcelable("user", user);
+
+        launchFragmentInHiltContainer(RewardsFragment.class, bundle, R.style.AppTheme, null);
+    }
+
+    @Test
+    public void test_rewardsFragment_hasCoreUiElementsCorrectlySetup() {
+        onView(withId(NAME_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("Hey, test-name")));
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
+        onView(withId(POINTS_LABEL_ID)).check(matches(isDisplayed())).check(matches(withText("Points")));
+        onView(withId(REWARDS_BUTTON_ID)).check(matches(isDisplayed())).check(matches(withText("GET REWARDED NOW!")));
+        onView(withId(REWARDS_TEXT_ID)).check(matches(withHint("Please enter your chosen reward code")));
+    }
+
+    @Test
+    public void test_rewardsFragment_givenCorrectCodeAndSufficientPoints_successfullyPurchasesItem() {
+        userRepository.addPoints(user, 10);
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
+        onView(withId(REWARDS_TEXT_ID)).perform(typeText("943248"), closeSoftKeyboard());
+        onView(withId(REWARDS_BUTTON_ID)).perform(click());
+        onView(withId(POPUP_TEXT)).inRoot(isDialog()).check(matches(withText("Code accepted, keep it up! Your new " +
+                "points balance is: 8")));
+        onView(withId(POPUP_CLOSE_BUTTON)).inRoot(isDialog()).perform(click());
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("8")));
+    }
+
+    @Test
+    public void test_rewardsFragment_givenCorrectCodeButInsufficientPoints_providesInsufficientPointsMessage() {
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
+        onView(withId(REWARDS_TEXT_ID)).perform(typeText("674382"), closeSoftKeyboard());
+        onView(withId(REWARDS_BUTTON_ID)).perform(click());
+        onView(withId(POPUP_TEXT)).inRoot(isDialog()).check(matches(withText("Woops! Unfortunately you don't have " +
+                "sufficient points for this reward. Please choose another reward or carry on doing a great job at the " +
+                "library to be able to get this")));
+        onView(withId(POPUP_CLOSE_BUTTON)).inRoot(isDialog()).perform(click());
+    }
+
+    @Test
+    public void test_rewardsFragment_givenIncorrectCode_doesNotPurchaseItem() {
+        userRepository.addPoints(user, 10);
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
+        onView(withId(REWARDS_TEXT_ID)).perform(typeText("incorrect-code"), closeSoftKeyboard());
+        onView(withId(REWARDS_BUTTON_ID)).perform(click());
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("10")));
+    }
+}

--- a/app/src/androidTest/java/com/example/librewards/TimerFragmentInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/librewards/TimerFragmentInstrumentedTest.java
@@ -10,18 +10,22 @@ import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.example.librewards.utils.FragmentTestUtils.launchFragmentInHiltContainer;
+import static com.example.librewards.utils.TestUtils.clearTables;
 import static org.hamcrest.CoreMatchers.not;
 
+import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.example.librewards.data.db.DatabaseHelper;
 import com.example.librewards.data.models.UserModel;
 import com.example.librewards.data.repositories.StartCodesRepository;
 import com.example.librewards.data.repositories.StopCodesRepository;
 import com.example.librewards.data.repositories.UserRepository;
 import com.example.librewards.views.TimerFragment;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +48,9 @@ public class TimerFragmentInstrumentedTest {
     StartCodesRepository startCodesRepository;
     @Inject
     StopCodesRepository stopCodesRepository;
+    @Inject
+    DatabaseHelper databaseHelper;
+    private SQLiteDatabase db;
     private static final int POINTS_VALUE_ID = R.id.pointsTimer;
     private static final int NAME_VALUE_ID = R.id.nameTimer;
     private static final int POINTS_LABEL_ID = R.id.pointsLabelTimer;
@@ -58,6 +65,7 @@ public class TimerFragmentInstrumentedTest {
     public void setUp() {
         hiltRule.inject();
         UserModel user = new UserModel(1, "test-name", 0);
+        db = databaseHelper.getWritableDatabase();
 
         startCodesRepository.populate();
         stopCodesRepository.populate();
@@ -104,5 +112,10 @@ public class TimerFragmentInstrumentedTest {
         onView(withId(TIMER_ID)).check(matches(withText("00:00")));
         onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the start code")));
         onView(withId(START_BUTTON_ID)).check(matches(isDisplayed()));
+    }
+
+    @After
+    public void tearDown() {
+        clearTables(db);
     }
 }

--- a/app/src/androidTest/java/com/example/librewards/TimerFragmentInstrumentedTest.java
+++ b/app/src/androidTest/java/com/example/librewards/TimerFragmentInstrumentedTest.java
@@ -1,108 +1,108 @@
-//package com.example.librewards;
-//
-//import static androidx.test.espresso.Espresso.onView;
-//import static androidx.test.espresso.action.ViewActions.click;
-//import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-//import static androidx.test.espresso.action.ViewActions.typeText;
-//import static androidx.test.espresso.assertion.ViewAssertions.matches;
-//import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-//import static androidx.test.espresso.matcher.ViewMatchers.withHint;
-//import static androidx.test.espresso.matcher.ViewMatchers.withId;
-//import static androidx.test.espresso.matcher.ViewMatchers.withText;
-//import static com.example.librewards.utils.FragmentTestUtils.launchFragmentInHiltContainer;
-//import static org.hamcrest.CoreMatchers.not;
-//
-//import android.os.Bundle;
-//
-//import androidx.test.ext.junit.runners.AndroidJUnit4;
-//
-//import com.example.librewards.data.models.UserModel;
-//import com.example.librewards.repositories.StartCodesRepositoryFake;
-//import com.example.librewards.repositories.StopCodesRepositoryFake;
-//import com.example.librewards.repositories.UserRepositoryFake;
-//import com.example.librewards.views.TimerFragment;
-//
-//import org.junit.Before;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//
-//import javax.inject.Inject;
-//
-//import dagger.hilt.android.testing.HiltAndroidRule;
-//import dagger.hilt.android.testing.HiltAndroidTest;
-//
-//@HiltAndroidTest
-//@RunWith(AndroidJUnit4.class)
-//public class TimerFragmentInstrumentedTest {
-//
-//    @Rule
-//    public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
-//    @Inject
-//    UserRepositoryFake userRepositoryFake;
-//    @Inject
-//    StartCodesRepositoryFake startCodesRepositoryFake;
-//    @Inject
-//    StopCodesRepositoryFake stopCodesRepositoryFake;
-//    private static final int POINTS_VALUE_ID = R.id.pointsTimer;
-//    private static final int NAME_VALUE_ID = R.id.nameTimer;
-//    private static final int POINTS_LABEL_ID = R.id.pointsLabelTimer;
-//    private static final int START_BUTTON_ID = R.id.startButton;
-//    private static final int TIMER_CODE_TEXT = R.id.timerCodeText;
-//    private static final int STOP_BUTTON_ID = R.id.stopButton;
-//    private static final int TIMER_ID = R.id.timer;
-//    private static final int POPUP_TEXT = R.id.popupText;
-//    private static final int POPUP_CLOSE_BUTTON = R.id.closeBtn;
-//
-//    @Before
-//    public void setUp() {
-//        hiltRule.inject();
-//        UserModel user = new UserModel(1, "test-name", 0);
-//
-//        startCodesRepositoryFake.populate();
-//        stopCodesRepositoryFake.populate();
-//        userRepositoryFake.setUser(user);
-//
-//        Bundle bundle = new Bundle();
-//        bundle.putParcelable("user", user);
-//
-//        launchFragmentInHiltContainer(TimerFragment.class, bundle, R.style.AppTheme, null);
-//    }
-//
-//    @Test
-//    public void test_timerFragment_hasCoreUiElementsCorrectlySetup() {
-//        onView(withId(NAME_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("Hey, test-name")));
-//        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
-//        onView(withId(POINTS_LABEL_ID)).check(matches(isDisplayed())).check(matches(withText("Points")));
-//        onView(withId(START_BUTTON_ID)).check(matches(isDisplayed())).check(matches(withText("start")));
-//        onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the start code")));
-//        onView(withId(STOP_BUTTON_ID)).check(matches(not(isDisplayed()))).check(matches(withText("stop")));
-//        onView(withId(TIMER_ID)).check(matches(isDisplayed())).check(matches(withText("00:00")));
-//    }
-//
-//    @Test
-//    public void test_timerFragment_startsTimerWithCorrectCode() throws InterruptedException {
-//        onView(withId(TIMER_CODE_TEXT)).perform(typeText("123456"), closeSoftKeyboard());
-//        onView(withId(START_BUTTON_ID)).perform(click());
-//        onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the stop code")));
-//        onView(withId(STOP_BUTTON_ID)).check(matches(isDisplayed()));
-//        Thread.sleep(1000);  // Wait a second for the timer to increment from default state
-//        onView(withId(TIMER_ID)).check(matches(not(withText("00:00"))));
-//        onView(withId(START_BUTTON_ID)).check(matches(not(isDisplayed())));
-//    }
-//
-//
-//    @Test
-//    public void test_timerFragment_startsTimerWithCorrectCodeAndStopsWithCorrectCode() {
-//        onView(withId(TIMER_CODE_TEXT)).perform(typeText("123456"), closeSoftKeyboard());
-//        onView(withId(START_BUTTON_ID)).perform(click());
-//        onView(withId(TIMER_CODE_TEXT)).perform(typeText("111111"), closeSoftKeyboard());
-//        onView(withId(STOP_BUTTON_ID)).check(matches(withText("stop"))).perform(click());
-//        onView(withId(POPUP_TEXT)).check(matches(withText("Unfortunately you have not spent the minimum required time " +
-//                "at the library to receive points!")));
-//        onView(withId(POPUP_CLOSE_BUTTON)).perform(click());
-//        onView(withId(TIMER_ID)).check(matches(withText("00:00")));
-//        onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the start code")));
-//        onView(withId(START_BUTTON_ID)).check(matches(isDisplayed()));
-//    }
-//}
+package com.example.librewards;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.example.librewards.utils.FragmentTestUtils.launchFragmentInHiltContainer;
+import static org.hamcrest.CoreMatchers.not;
+
+import android.os.Bundle;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.example.librewards.data.models.UserModel;
+import com.example.librewards.data.repositories.StartCodesRepository;
+import com.example.librewards.data.repositories.StopCodesRepository;
+import com.example.librewards.data.repositories.UserRepository;
+import com.example.librewards.views.TimerFragment;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class TimerFragmentInstrumentedTest {
+
+    @Rule
+    public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+    @Inject
+    UserRepository userRepository;
+    @Inject
+    StartCodesRepository startCodesRepository;
+    @Inject
+    StopCodesRepository stopCodesRepository;
+    private static final int POINTS_VALUE_ID = R.id.pointsTimer;
+    private static final int NAME_VALUE_ID = R.id.nameTimer;
+    private static final int POINTS_LABEL_ID = R.id.pointsLabelTimer;
+    private static final int START_BUTTON_ID = R.id.startButton;
+    private static final int TIMER_CODE_TEXT = R.id.timerCodeText;
+    private static final int STOP_BUTTON_ID = R.id.stopButton;
+    private static final int TIMER_ID = R.id.timer;
+    private static final int POPUP_TEXT = R.id.popupText;
+    private static final int POPUP_CLOSE_BUTTON = R.id.closeBtn;
+
+    @Before
+    public void setUp() {
+        hiltRule.inject();
+        UserModel user = new UserModel(1, "test-name", 0);
+
+        startCodesRepository.populate();
+        stopCodesRepository.populate();
+        userRepository.addName("test-name");
+
+        Bundle bundle = new Bundle();
+        bundle.putParcelable("user", user);
+
+        launchFragmentInHiltContainer(TimerFragment.class, bundle, R.style.AppTheme, null);
+    }
+
+    @Test
+    public void test_timerFragment_hasCoreUiElementsCorrectlySetup() {
+        onView(withId(NAME_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("Hey, test-name")));
+        onView(withId(POINTS_VALUE_ID)).check(matches(isDisplayed())).check(matches(withText("0")));
+        onView(withId(POINTS_LABEL_ID)).check(matches(isDisplayed())).check(matches(withText("Points")));
+        onView(withId(START_BUTTON_ID)).check(matches(isDisplayed())).check(matches(withText("start")));
+        onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the start code")));
+        onView(withId(STOP_BUTTON_ID)).check(matches(not(isDisplayed()))).check(matches(withText("stop")));
+        onView(withId(TIMER_ID)).check(matches(isDisplayed())).check(matches(withText("00:00")));
+    }
+
+    @Test
+    public void test_timerFragment_startsTimerWithCorrectCode() throws InterruptedException {
+        onView(withId(TIMER_CODE_TEXT)).perform(typeText("583927"), closeSoftKeyboard());
+        onView(withId(START_BUTTON_ID)).perform(click());
+        onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the stop code")));
+        onView(withId(STOP_BUTTON_ID)).check(matches(isDisplayed()));
+        Thread.sleep(1000);  // Wait a second for the timer to increment from default state
+        onView(withId(TIMER_ID)).check(matches(not(withText("00:00"))));
+        onView(withId(START_BUTTON_ID)).check(matches(not(isDisplayed())));
+    }
+
+
+    @Test
+    public void test_timerFragment_startsTimerWithCorrectCodeAndStopsWithCorrectCode() {
+        onView(withId(TIMER_CODE_TEXT)).perform(typeText("583927"), closeSoftKeyboard());
+        onView(withId(START_BUTTON_ID)).perform(click());
+        onView(withId(TIMER_CODE_TEXT)).perform(typeText("241859"), closeSoftKeyboard());
+        onView(withId(STOP_BUTTON_ID)).check(matches(withText("stop"))).perform(click());
+        onView(withId(POPUP_TEXT)).check(matches(withText("Unfortunately you have not spent the minimum required time " +
+                "at the library to receive points!")));
+        onView(withId(POPUP_CLOSE_BUTTON)).perform(click());
+        onView(withId(TIMER_ID)).check(matches(withText("00:00")));
+        onView(withId(TIMER_CODE_TEXT)).check(matches(withHint("Please enter the start code")));
+        onView(withId(START_BUTTON_ID)).check(matches(isDisplayed()));
+    }
+}

--- a/app/src/androidTest/java/com/example/librewards/utils/TestUtils.java
+++ b/app/src/androidTest/java/com/example/librewards/utils/TestUtils.java
@@ -1,0 +1,12 @@
+package com.example.librewards.utils;
+
+import android.database.sqlite.SQLiteDatabase;
+
+public class TestUtils {
+    public static void clearTables(SQLiteDatabase db){
+        db.delete("user_table", null, null);
+        db.delete("start_codes_table", null, null);
+        db.delete("stop_codes_table", null, null);
+        db.delete("reward_codes_table", null, null);
+    }
+}

--- a/app/src/main/java/com/example/librewards/data/repositories/UserRepository.java
+++ b/app/src/main/java/com/example/librewards/data/repositories/UserRepository.java
@@ -9,14 +9,14 @@ import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.example.librewards.data.db.DatabaseHelper;
-import com.example.librewards.data.notifiers.UserChangeNotifier;
 import com.example.librewards.data.models.UserModel;
+import com.example.librewards.data.notifiers.UserChangeNotifier;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
-public class UserRepository implements UserRepositoryInterface{
+public class UserRepository implements UserRepositoryInterface {
     private final SQLiteDatabase db;
     private final DatabaseHelper dbHelper;
 
@@ -28,6 +28,7 @@ public class UserRepository implements UserRepositoryInterface{
 
     public void addName(String name) {
         ContentValues contentValues = new ContentValues();
+        contentValues.put(ID_COLUMN_NAME, 1);
         contentValues.put(NAME_COLUMN_NAME, name);
         db.insert(USER_TABLE_NAME, null, contentValues);
         UserChangeNotifier.notifyNameChange(name);
@@ -35,8 +36,10 @@ public class UserRepository implements UserRepositoryInterface{
 
     public UserModel getUser() {
         int id = 1;
-        String name = dbHelper.getString(USER_TABLE_NAME, NAME_COLUMN_NAME, null, null);
-        int points = dbHelper.getInt(USER_TABLE_NAME, POINTS_COLUMN_NAME, null, null);
+        String name = dbHelper.getString(USER_TABLE_NAME, NAME_COLUMN_NAME, ID_COLUMN_NAME + " = ?",
+                new String[]{String.valueOf(id)});
+        int points = dbHelper.getInt(USER_TABLE_NAME, POINTS_COLUMN_NAME, ID_COLUMN_NAME + " = ?",
+                new String[]{String.valueOf(id)});
 
         return new UserModel(id, name, points);
     }


### PR DESCRIPTION
- test leaks made me realise that it is possible (Although extremely rare) that given a change in the application code, another row may be created in the user table. DB functions have been modified to only amend first row
- Fragment instrumented tests follow same principle as the MainActivity and use real repositories so that tests can act as integration tests